### PR TITLE
Support multiple Creator publish instances per node

### DIFF
--- a/client/ayon_silhouette/plugins/create/create_matte_shapes.py
+++ b/client/ayon_silhouette/plugins/create/create_matte_shapes.py
@@ -1,6 +1,6 @@
 import fx
 
-from ayon_core.lib import EnumDef
+from ayon_core.lib import EnumDef, UILabelDef
 from ayon_silhouette.api import plugin
 
 
@@ -21,7 +21,7 @@ class CreateMatteShapes(plugin.SilhouetteCreator):
         # instance directly, not after transient data was added to the instance
         # in the `create` or `collect` method. So we must find the node by
         # node id.
-        node_id = instance.data.get("instance_id")
+        node_id = instance.data.get("node_id")
         node = fx.findObject(node_id)
 
         if not node:
@@ -47,6 +47,7 @@ class CreateMatteShapes(plugin.SilhouetteCreator):
             })
 
         attr_defs = [
+            UILabelDef(f"Node: {node.label}", key="node_label"),
             EnumDef(
                 "shapes",
                 label="Export shapes",

--- a/client/ayon_silhouette/plugins/create/create_track_points.py
+++ b/client/ayon_silhouette/plugins/create/create_track_points.py
@@ -1,6 +1,6 @@
 import fx
 
-from ayon_core.lib import EnumDef
+from ayon_core.lib import EnumDef, UILabelDef
 from ayon_silhouette.api import plugin
 
 
@@ -22,7 +22,7 @@ class CreateTrackPoints(plugin.SilhouetteCreator):
         # instance directly, not after transient data was added to the instance
         # in the `create` or `collect` method. So we must find the node by
         # node id.
-        node_id = instance.data.get("instance_id")
+        node_id = instance.data.get("node_id")
         node = fx.findObject(node_id)
 
         if not node:
@@ -49,6 +49,7 @@ class CreateTrackPoints(plugin.SilhouetteCreator):
             })
 
         attr_defs = [
+            UILabelDef(f"<b>Node</b>: {node.label}", key="node_label"),
             EnumDef(
                 "trackers",
                 label="Export trackers",


### PR DESCRIPTION
## Changelog Description

Imprint instances as dict of instances on a node in key `AYON_instances` so that multiple unique publish instances can exist on a single Silhouette node

## Additional review information

A single node in the graph can now have multiple publish instances so you can e.g. imprint the same node with multiple separate publish instances. This was you can publish e.g. a subset of the rotos into individual products, but also allow a single roto node to publish both a `matteshapes` instance _and_ a `trackpoints` instance. This makes it so the following is supported:

- Selectively exporting only a part of the roto node (selected shapes) to separate products
- Having a track and roto on the same roto node inside Silhouette, which would require both the matteshapes and trackpoints product types to be published from the single node.

**Remarks**

This does have the side effect that it may become harder to figure out which node belongs to the publish instance because you may have many instances now targeting a single publish node.

**TODO**

- [ ] On remove, do not directly delete the node, but only do so if no remaining instances are active on the node. Otherwise just drop the imprinted data for the instance.

## Testing notes:

_Note: Any instances generated without this PR are incompatible with this PR and will not be detected. This is a backwards incompatible change!_

1. Creating instances should work
2. Collecting instances (resetting publisher UI) should find these instances again correctly
3. Storing data per instance (e.g. toggle per instance) should work as intended.
4. Publishing should work
5. Duplicating the node (copy/pasting) should be correctly detected and work fine with publisher UI