### PR TITLE
Support layered objects lists for shapes and trackers

### DIFF
--- a/client/ayon_silhouette/api/lib.py
+++ b/client/ayon_silhouette/api/lib.py
@@ -2,7 +2,7 @@
 import contextlib
 import json
 import logging
-from typing import Optional
+from typing import Optional, Iterator, Tuple
 
 from qtpy import QtCore, QtWidgets
 import fx
@@ -297,8 +297,15 @@ def capture_messageboxes(callback):
         timer.stop()
 
 
-def iter_children(node, prefix=None):
-    """Iterate over all children of a node recursively."""
+def iter_children(
+        node: fx.Node,
+        prefix: Optional[str] = None
+) -> Iterator[Tuple[fx.Node, str]]:
+    """Iterate over all children of a node recursively.
+
+    This yields the node together with a label that indicates the full path
+    from the root node passed to the function.
+    """
     children = node.children
     if not children:
         return

--- a/client/ayon_silhouette/api/lib.py
+++ b/client/ayon_silhouette/api/lib.py
@@ -249,3 +249,17 @@ def reset_session_settings(session=None, task_entity=None):
     with undo_chunk("Reset session settings"):
         set_resolution_from_entity(session, task_entity)
         set_frame_range_from_entity(session, task_entity)
+
+
+def iter_children(node, prefix=None):
+    """Iterate over all children of a node recursively."""
+    children = node.children
+    if not children:
+        return
+    for child in reversed(children):
+        # Yield with a nested label so we can easily display it nicely
+        label = child.label
+        if prefix:
+            label = f"{prefix} > {label}"
+        yield child, label
+        yield from iter_children(child, prefix=label)

--- a/client/ayon_silhouette/plugins/create/create_matte_shapes.py
+++ b/client/ayon_silhouette/plugins/create/create_matte_shapes.py
@@ -1,7 +1,7 @@
 import fx
 
 from ayon_core.lib import EnumDef
-from ayon_silhouette.api import plugin
+from ayon_silhouette.api import plugin, lib
 
 
 class CreateMatteShapes(plugin.SilhouetteCreator):
@@ -27,19 +27,11 @@ class CreateMatteShapes(plugin.SilhouetteCreator):
         if not node:
             return []
 
-        shapes = [
-            shape for shape in node.children if isinstance(shape, fx.Shape)
+        items = [
+            {"label": label, "value": shape}
+            for shape, label in lib.iter_children(node)
+            if isinstance(shape, fx.Shape)
         ]
-        # Iterate reversed so they appear as same order in the object list
-        # in Silhouette user interface
-        items = []
-        for shape in reversed(shapes):
-            items.append({
-                "label": shape.label,
-                "value": shape.id
-            })
-
-
         if not items:
             items.append({
                 "label": "<No shapes found>",

--- a/client/ayon_silhouette/plugins/create/create_track_points.py
+++ b/client/ayon_silhouette/plugins/create/create_track_points.py
@@ -1,7 +1,7 @@
 import fx
 
 from ayon_core.lib import EnumDef
-from ayon_silhouette.api import plugin
+from ayon_silhouette.api import plugin, lib
 
 
 class CreateTrackPoints(plugin.SilhouetteCreator):
@@ -28,20 +28,11 @@ class CreateTrackPoints(plugin.SilhouetteCreator):
         if not node:
             return []
 
-        trackers = [
-            tracker for tracker in node.children
+        items = [
+            {"label": label, "value": tracker}
+            for tracker, label in lib.iter_children(node)
             if isinstance(tracker, fx.Tracker)
         ]
-        # Iterate reversed so they appear as same order in the object list
-        # in Silhouette user interface
-        items = []
-        for tracker in reversed(trackers):
-            items.append({
-                "label": tracker.label,
-                "value": tracker.id
-            })
-
-
         if not items:
             items.append({
                 "label": "<No trackers found>",

--- a/client/ayon_silhouette/plugins/publish/extract_shapes.py
+++ b/client/ayon_silhouette/plugins/publish/extract_shapes.py
@@ -31,7 +31,8 @@ class ExtractNukeShapes(publish.Extractor):
             shapes = [fx.findObject(shape_id) for shape_id in shape_ids]
         else:
             shapes = [
-                shape for shape in node.children if isinstance(shape, fx.Shape)
+                shape for shape, _label in lib.iter_children(node)
+                if isinstance(shape, fx.Shape)
             ]
 
         with lib.maintained_selection():

--- a/client/ayon_silhouette/plugins/publish/extract_track.py
+++ b/client/ayon_silhouette/plugins/publish/extract_track.py
@@ -35,7 +35,7 @@ class SilhouetteExtractAfterEffectsTrack(publish.Extractor):
             ]
         else:
             trackers = [
-                tracker for tracker in node.children
+                tracker for tracker, _label in lib.iter_children(node)
                 if isinstance(tracker, fx.Tracker)
             ]
 


### PR DESCRIPTION
## Changelog Description

For the Creators and extractors include all shapes and trackers, also the nested ones that are e.g. parented under a layer.

## Additional review information

You can add a layer in the Object List panel:
![image](https://github.com/user-attachments/assets/663bba1b-be23-48a6-bd91-2a3abd456aa1)

The creator's export filter will now list the nested entries too:
![image](https://github.com/user-attachments/assets/8ddf7696-8cb9-434b-b57c-0705f4dbdc25)

## Testing notes:

1. Publishing should work as intended with and without selected entries
