### PR TITLE
Workfile Templates: Load Source placeholder in Sources + transfer connections to loaded products

### DIFF
--- a/client/ayon_silhouette/api/lib.py
+++ b/client/ayon_silhouette/api/lib.py
@@ -395,3 +395,35 @@ def unzip(source, destination):
     with _ZipFile(source) as zr:
         zr.extractall(destination)
     log.debug(f"Extracted '{source}' to '{destination}'")
+
+
+@undo_chunk("Transfer connections")
+def transfer_connections(
+    source: fx.Node,
+    destination: fx.Node,
+    inputs: bool = True,
+    outputs: bool = True):
+    """Transfer connections from one node to another."""
+    # TODO: Match port by something else than name? (e.g. idx?)
+    # Transfer connections from inputs
+    if inputs:
+        for _input in source.connectedInputs:
+            name = _input.name
+            destination_input = next((
+                port for port in destination.inputs
+                if port.name == name), None)
+            if destination_input:
+                destination_input.disconnect()
+                _input.source.connect(destination_input)
+
+    # Transfer connections from outputs
+    if outputs:
+        for output in source.connectedOutputs:
+            name = output.name
+            destination_output = next((
+                port for port in destination.outputs
+                if port.name == name), None)
+            if destination_output:
+                for target in output.targets:
+                    target.disconnect()
+                    destination_output.connect(target)

--- a/client/ayon_silhouette/api/workfile_template_builder.py
+++ b/client/ayon_silhouette/api/workfile_template_builder.py
@@ -147,8 +147,14 @@ class SilhouettePlaceholderPlugin(PlaceholderPlugin):
     def delete_placeholder(self, placeholder: PlaceholderItem):
         """Remove placeholder if building was successful"""
         node = placeholder.transient_data["node"]  # noqa
-        session = node.session
-        session.removeNode(node)
+        if isinstance(node, fx.Node):
+            session = node.session
+            session.removeNode(node)
+        elif isinstance(node, fx.Source):
+            project = node.parent.parent  # Source -> SourceItem -> Project
+            project.removeItem(node)
+        else:
+            raise TypeError(f"Unsupported placeholder node: {node}")
 
 
 @lib.undo_chunk("Build workfile template")
@@ -174,7 +180,6 @@ def create_placeholder(*args):
     window = WorkfileBuildPlaceholderDialog(host, builder,
                                             parent=get_main_window())
     window.show()
-
 
 def update_placeholder(*args):
     host = registered_host()

--- a/client/ayon_silhouette/api/workfile_template_builder.py
+++ b/client/ayon_silhouette/api/workfile_template_builder.py
@@ -87,7 +87,8 @@ class SilhouettePlaceholderPlugin(PlaceholderPlugin):
                            placeholder_item: PlaceholderItem,
                            placeholder_data: dict):
         node = placeholder_item.transient_data["node"]  # noqa
-        imprint(node, placeholder_data)
+        placeholder_data["plugin_identifier"] = self.identifier
+        imprint(node, placeholder_data, key=self.data_key)
 
     def _collect_placeholder_nodes(self) -> Dict[str, List[fx.Node]]:
         nodes = self.builder.get_shared_populate_data("placeholder_nodes")

--- a/client/ayon_silhouette/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_silhouette/plugins/workfile_build/load_placeholder.py
@@ -34,4 +34,5 @@ class SilhouettePlaceholderLoadPlugin(SilhouettePlaceholderPlugin,
                 representation.
             failed (bool): Loading of representation failed.
         """
-        pass
+        if not placeholder.data.get("keep_placeholder", True):
+            self.delete_placeholder(placeholder)

--- a/client/ayon_silhouette/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_silhouette/plugins/workfile_build/load_placeholder.py
@@ -2,16 +2,40 @@ from ayon_core.pipeline.workfile.workfile_template_builder import (
     LoadPlaceholderItem,
     PlaceholderLoadMixin,
 )
+
+import ayon_silhouette.api.workfile_template_builder
+import importlib
+importlib.reload(ayon_silhouette.api.workfile_template_builder)
+
+import fx
+
 from ayon_silhouette.api.workfile_template_builder import (
     SilhouettePlaceholderPlugin
 )
 
 
-class SilhouettePlaceholderLoadPlugin(SilhouettePlaceholderPlugin,
-                                PlaceholderLoadMixin):
+class SilhouettePlaceholderLoadPlugin(
+    SilhouettePlaceholderPlugin,
+    PlaceholderLoadMixin):
     identifier = "silhouette.placeholder.load"
     label = "Silhouette load"
     item_class = LoadPlaceholderItem
+
+    def _create_placeholder_node(self, placeholder_data, session):
+        if placeholder_data["loader"] == "SourceLoader":
+            # Special case for source loader because we want to create
+            # the placeholder entry in Sources, not as a Node
+            project = fx.activeProject()
+
+            # Add Source item to the project
+            source = fx.Source("")
+
+            # Provide a nice label indicating the product
+            source.label = "Placeholder"
+            project.addItem(source)
+            return source
+
+        return super()._create_placeholder_node(placeholder_data, session)
 
     def populate_placeholder(self, placeholder):
         self.populate_load_placeholder(placeholder)

--- a/client/ayon_silhouette/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_silhouette/plugins/workfile_build/load_placeholder.py
@@ -1,10 +1,11 @@
+import fx
+
 from ayon_core.pipeline.workfile.workfile_template_builder import (
     LoadPlaceholderItem,
     PlaceholderLoadMixin,
 )
 
-import fx
-
+from ayon_silhouette.api import lib
 from ayon_silhouette.api.workfile_template_builder import (
     SilhouettePlaceholderPlugin
 )
@@ -46,13 +47,82 @@ class SilhouettePlaceholderLoadPlugin(
     def get_placeholder_options(self, options=None):
         return self.get_load_plugin_options(options)
 
-    def post_placeholder_process(self, placeholder, failed):
-        """Cleanup placeholder after load of its corresponding representations.
+    def _before_placeholder_load(self, placeholder):
+        containers = list(self.builder.host.get_containers())
+        placeholder.data["init_containers"] = containers
 
-        Args:
-            placeholder (PlaceholderItem): Item which was just used to load
-                representation.
-            failed (bool): Loading of representation failed.
-        """
+    def post_placeholder_process(self, placeholder, failed):
+
+        # Get loaded nodes from the loaded representation
+        containers = list(self.builder.host.get_containers())
+        loaded_containers = [
+            container for container in containers
+            if container not in placeholder.data["init_containers"]
+        ]
+        loaded_items = [
+            container.get("_item") for container in loaded_containers
+        ]
+
+        # Transfer connections from placeholder to loaded representation(s)
+        # Note: When a single node placeholder turns into multiple nodes then
+        #  the output connections are copied only to the first because the
+        #  destination can only be connected once.
+        node = placeholder.transient_data["node"]
+        if isinstance(node, fx.Node):
+            # Use the loaded node as a replacement
+            # TODO: Support 'load into existing placeholder' node or alike to
+            #   support single placeholder to have multiple load placeholders
+            #   like Matte Shapes + Track Points both loaded to one roto node.
+            position = node.getState("graph.pos")
+            for loaded_item in loaded_items:
+                lib.transfer_connections(node, loaded_items)
+
+                # Try to match the node position with the placeholder
+                loaded_item.setState("graph.pos", position)
+
+        elif isinstance(node, fx.Source):
+            # Clone dependency nodes of the source node in the graph
+            # (because it may be loaded multiple times from one placeholder)
+            # and then replace cloned node stream sources to the loaded source
+            # products + transfer node connections from the dependency in-graph
+            # placeholder
+            streams = ["stream.primary",
+                       "stream.secondary",
+                       "stream.depth"]
+            for dependency in node.dependencies:
+                # The 'dependency' is the input node in the session graph
+                # that references the source item as a view stream.
+                dependency: fx.Node
+
+                # Create a clone for every loaded item
+                for loaded_item in loaded_items:
+                    clone = dependency.clone()
+                    dependency.parent.addNode(clone)
+
+                    # match label with loaded source item
+                    clone.label = loaded_item.label
+
+                    # Update the streams to use the new loaded source
+                    for stream in streams:
+                        stream_property = clone.property(stream)
+                        if stream_property is None:
+                            self.log.warning(
+                                f"Node {node} has no stream property: {stream}")
+                            continue
+
+                        # If the stream references the placeholder source item
+                        # then remap it to the loaded item
+                        if stream_property.value == node:
+                            stream_property.value = loaded_item
+
+                    lib.transfer_connections(dependency, clone)
+
         if not placeholder.data.get("keep_placeholder", True):
+
+            if isinstance(node, fx.Source):
+                project = fx.activeProject()
+                # Delete all placeholder dependencies in the graph
+                for dependency in node.dependencies:
+                    project.removeItem(dependency)
+
             self.delete_placeholder(placeholder)

--- a/client/ayon_silhouette/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_silhouette/plugins/workfile_build/load_placeholder.py
@@ -3,10 +3,6 @@ from ayon_core.pipeline.workfile.workfile_template_builder import (
     PlaceholderLoadMixin,
 )
 
-import ayon_silhouette.api.workfile_template_builder
-import importlib
-importlib.reload(ayon_silhouette.api.workfile_template_builder)
-
 import fx
 
 from ayon_silhouette.api.workfile_template_builder import (


### PR DESCRIPTION
## Changelog Description

- Match graph position for loaded products to the placeholder node (for Load placeholders like load matteshapes or trackpoints)
- Create "Load Source" placeholder in project sources instead of as node in graph to allow much better placeholder behavior where the source can be re-used in graph, accordingly.
- Transfer connections from the placeholder nodes to the loaded items.

## Additional review information

Fixes draft implementation of workfile templates.

_Note_: When building a template where a single placeholder loads multiple products then on build the multiple entries will appear on top of each other in the graph with only the _last_ loaded product to receive get the outputs transferred because the destinations can only be connected to ONE of the loader items.

**Note that "Create" placeholders have been untested still and likely won't work - so please test only Load Placeholders**

## Testing notes:

1. Create a workfile template file
2. Updating placeholders (incl "Load Source" load placeholder) should work when selecting in the "Sources" panel
3. Build the workfile template.

Template "Load Placeholders" should work.
