### PR TITLE
Validate existence of trackers/shapes including nested children

### DIFF
--- a/client/ayon_silhouette/plugins/publish/validate_shapes.py
+++ b/client/ayon_silhouette/plugins/publish/validate_shapes.py
@@ -2,6 +2,7 @@ import pyblish.api
 import fx
 
 from ayon_core.pipeline import publish
+from ayon_silhouette.api import lib
 
 
 class ValidateShapes(pyblish.api.InstancePlugin):
@@ -16,7 +17,8 @@ class ValidateShapes(pyblish.api.InstancePlugin):
         # Node should be a node that contains 'shapes' children
         node = instance.data["transientData"]["instance_node"]
         if not any(
-            shape for shape in node.children if isinstance(shape, fx.Shape)
+            shape for shape, _label in lib.iter_children(node)
+            if isinstance(shape, fx.Shape)
         ):
             raise publish.PublishValidationError(
                 "No shapes found on node: {0}".format(node.label)

--- a/client/ayon_silhouette/plugins/publish/validate_trackers.py
+++ b/client/ayon_silhouette/plugins/publish/validate_trackers.py
@@ -2,6 +2,7 @@ import pyblish.api
 import fx
 
 from ayon_core.pipeline import publish
+from ayon_silhouette.api import lib
 
 
 class ValidateTrackers(pyblish.api.InstancePlugin):
@@ -16,8 +17,7 @@ class ValidateTrackers(pyblish.api.InstancePlugin):
         # Node should be a node that contains 'tracker' children
         node = instance.data["transientData"]["instance_node"]
         if not any(
-            tracker
-            for tracker in node.children
+            tracker for tracker, _label in lib.iter_children(node)
             if isinstance(tracker, fx.Tracker)
         ):
             raise publish.PublishValidationError(


### PR DESCRIPTION
## Changelog Description

Fixes validation for nodes that have no top level children trackers or matte shapes, but only in nested groups/layers in its objects list.

## Additional review information

Fixes false invalidation even though the node was actually valid.

## Testing notes:

1. Create roto with nested object list (with shapes nested)
2. Validation should pass to publish matte shapes.
(Same for tracker exports)
