### PR TITLE
Expose settings to allow enable/disable Shapes and Tracker export file types

### DIFF
--- a/client/ayon_silhouette/plugins/publish/extract_shapes.py
+++ b/client/ayon_silhouette/plugins/publish/extract_shapes.py
@@ -18,6 +18,8 @@ class ExtractNukeShapes(publish.Extractor):
     extension = "nk"
     io_module = "Nuke 9+ Shapes"
 
+    settings_category = "silhouette"
+
     capture_messageboxes = False
 
     def process(self, instance):

--- a/client/ayon_silhouette/plugins/publish/extract_shapes.py
+++ b/client/ayon_silhouette/plugins/publish/extract_shapes.py
@@ -8,7 +8,8 @@ from ayon_core.pipeline import publish
 from ayon_silhouette.api import lib
 
 
-class ExtractNukeShapes(publish.Extractor):
+class ExtractNukeShapes(publish.Extractor,
+                        publish.OptionalPyblishPluginMixin):
     """Extract node as Nuke 9+ Shapes."""
 
     label = "Extract Nuke 9+ Shapes"
@@ -23,6 +24,8 @@ class ExtractNukeShapes(publish.Extractor):
     capture_messageboxes = False
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
 
         # Define extract output file path
         dir_path = self.staging_dir(instance)

--- a/client/ayon_silhouette/plugins/publish/extract_track.py
+++ b/client/ayon_silhouette/plugins/publish/extract_track.py
@@ -18,6 +18,8 @@ class SilhouetteExtractAfterEffectsTrack(publish.Extractor):
     extension = "txt"
     io_module = "After Effects"
 
+    settings_category = "silhouette"
+
     capture_messageboxes = True
 
     def process(self, instance):

--- a/client/ayon_silhouette/plugins/publish/extract_track.py
+++ b/client/ayon_silhouette/plugins/publish/extract_track.py
@@ -9,7 +9,8 @@ from ayon_core.pipeline import publish
 from ayon_silhouette.api import lib
 
 
-class SilhouetteExtractAfterEffectsTrack(publish.Extractor):
+class SilhouetteExtractAfterEffectsTrack(publish.Extractor,
+                                         publish.OptionalPyblishPluginMixin):
     """Extract After Effects .txt track from Silhouette."""
     label = "Extract After Effects .txt"
     hosts = ["silhouette"]
@@ -23,6 +24,8 @@ class SilhouetteExtractAfterEffectsTrack(publish.Extractor):
     capture_messageboxes = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
 
         # Define extract output file path
         dir_path = self.staging_dir(instance)

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -3,11 +3,16 @@ from .imageio import ImageIOSettings, DEFAULT_IMAGEIO_SETTINGS
 from .templated_workfile_build import (
     TemplatedWorkfileBuildModel
 )
+from .publish import PublishPluginsModel, DEFAULT_SILHOUETTE_PUBLISH_SETTINGS
 
 class SilhouetteSettings(BaseSettingsModel):
     imageio: ImageIOSettings = SettingsField(
         default_factory=ImageIOSettings,
         title="Color Management (ImageIO)"
+    )
+    publish: PublishPluginsModel = SettingsField(
+        title="Publish",
+        default_factory=PublishPluginsModel
     )
     templated_workfile_build: TemplatedWorkfileBuildModel = SettingsField(
         title="Templated Workfile Build",
@@ -17,6 +22,7 @@ class SilhouetteSettings(BaseSettingsModel):
 
 DEFAULT_VALUES = {
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
+    "publish": DEFAULT_SILHOUETTE_PUBLISH_SETTINGS,
     "templated_workfile_build": {
         "profiles": []
     }

--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -1,0 +1,84 @@
+from ayon_server.settings import (
+    BaseSettingsModel,
+    SettingsField
+)
+
+
+class BasicEnabledStatesModel(BaseSettingsModel):
+    enabled: bool = SettingsField(
+        title="Enabled", description="Whether the plug-in is enabled"
+    )
+    optional: bool = SettingsField(
+        title="Optional",
+        description=(
+            "If the plug-in is enabled, this defines whether it can be "
+            "activated or deactivated by the artist in the publisher UI."
+        ),
+    )
+    active: bool = SettingsField(
+        title="Active",
+        description=(
+            "If the plug-in is optional, this defines the default "
+            "enabled state."
+        ),
+    )
+
+
+class PublishPluginsModel(BaseSettingsModel):
+    # Shapes
+    ExtractNukeShapes: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
+        title="Extract Nuke 9+ .nk Shapes",
+        section="Extract Shapes")
+    ExtractSilhouetteShapes: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
+        title="Extract Silhouette .fxs Shapes.")
+    ExtractShakeShapes: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
+        title="Extract Shake 4.x .ssf Shapes")
+    ExtractFusionShapes: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
+        title="Extract Fusion .settings Shapes")
+
+    # Trackers
+    SilhouetteExtractAfterEffectsTrack: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
+        title="Extract After Effects .txt Trackers",
+        section="Extract Trackers")
+    SilhouetteExtractNuke5Track: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
+        title="Extract Nuke 5 .nk Trackers")
+
+
+DEFAULT_SILHOUETTE_PUBLISH_SETTINGS = {
+    "ExtractNukeShapes": {
+        "enabled": True,
+        "optional": False,
+        "active": True,
+    },
+    "ExtractSilhouetteShapes": {
+        "enabled": True,
+        "optional": False,
+        "active": True,
+    },
+    "ExtractShakeShapes": {
+        "enabled": False,
+        "optional": False,
+        "active": True,
+    },
+    "ExtractFusionShapes": {
+        "enabled": False,
+        "optional": False,
+        "active": True,
+    },
+    "SilhouetteExtractAfterEffectsTrack": {
+        "enabled": True,
+        "optional": False,
+        "active": True,
+    },
+    "SilhouetteExtractNuke5Track": {
+        "enabled": True,
+        "optional": False,
+        "active": True,
+    },
+}

--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -1,7 +1,4 @@
-from ayon_server.settings import (
-    BaseSettingsModel,
-    SettingsField
-)
+from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
 class BasicEnabledStatesModel(BaseSettingsModel):
@@ -29,16 +26,20 @@ class PublishPluginsModel(BaseSettingsModel):
     ExtractNukeShapes: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
         title="Extract Nuke 9+ .nk Shapes",
-        section="Extract Shapes")
+        section="Extract Shapes",
+    )
     ExtractSilhouetteShapes: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
-        title="Extract Silhouette .fxs Shapes.")
+        title="Extract Silhouette .fxs Shapes.",
+    )
     ExtractShakeShapes: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
-        title="Extract Shake 4.x .ssf Shapes")
+        title="Extract Shake 4.x .ssf Shapes",
+    )
     ExtractFusionShapes: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
-        title="Extract Fusion .settings Shapes")
+        title="Extract Fusion .settings Shapes",
+    )
 
     # Trackers
     SilhouetteExtractAfterEffectsTrack: BasicEnabledStatesModel = (
@@ -50,7 +51,8 @@ class PublishPluginsModel(BaseSettingsModel):
     )
     SilhouetteExtractNuke5Track: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
-        title="Extract Nuke 5 .nk Trackers")
+        title="Extract Nuke 5 .nk Trackers",
+    )
 
 
 DEFAULT_SILHOUETTE_PUBLISH_SETTINGS = {

--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -41,10 +41,13 @@ class PublishPluginsModel(BaseSettingsModel):
         title="Extract Fusion .settings Shapes")
 
     # Trackers
-    SilhouetteExtractAfterEffectsTrack: BasicEnabledStatesModel = SettingsField(
-        default_factory=BasicEnabledStatesModel,
-        title="Extract After Effects .txt Trackers",
-        section="Extract Trackers")
+    SilhouetteExtractAfterEffectsTrack: BasicEnabledStatesModel = (
+        SettingsField(
+            default_factory=BasicEnabledStatesModel,
+            title="Extract After Effects .txt Trackers",
+            section="Extract Trackers",
+        )
+    )
     SilhouetteExtractNuke5Track: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
         title="Extract Nuke 5 .nk Trackers")


### PR DESCRIPTION
## Changelog Description

Expose settings to allow enable/disable Shapes and Tracker export file types

## Additional review information

Part of https://github.com/ynput/ayon-silhouette/issues/2

## Testing notes:

1. You can now define enabled/optional state for extractors in Settings