### PR TITLE
Add support for extracting Nuke 6.2+ shapes

### DIFF
--- a/client/ayon_silhouette/plugins/publish/extract_shapes.py
+++ b/client/ayon_silhouette/plugins/publish/extract_shapes.py
@@ -1,5 +1,6 @@
 import os
 import contextlib
+from typing import Optional
 
 from qtpy import QtWidgets
 import fx
@@ -18,6 +19,9 @@ class ExtractNukeShapes(publish.Extractor,
 
     extension = "nk"
     io_module = "Nuke 9+ Shapes"
+
+    # When set, override the representation name and `outputName`
+    override_name: Optional[str] = None
 
     settings_category = "silhouette"
 
@@ -54,17 +58,29 @@ class ExtractNukeShapes(publish.Extractor,
                 fx.io_modules[self.io_module].export(path)
 
         representation = {
-            "name": self.extension,
+            "name": self.override_name or self.extension,
             "ext": self.extension,
             "files": filename,
             "stagingDir": dir_path,
         }
+        if self.override_name:
+            representation["outputName"] = self.override_name
         instance.data.setdefault("representations", []).append(representation)
 
         self.log.debug(f"Extracted instance '{instance.name}' to: {path}")
 
     def on_captured_messagebox(self, messagebox: QtWidgets.QMessageBox):
         pass
+
+
+class ExtractNuke62Shapes(ExtractNukeShapes):
+    """Extract node as Nuke 6.2+ Shapes."""
+    families = ["matteshapes"]
+    label = "Extract Nuke 6.2+ Shapes"
+    io_module = "Nuke 6.2+ Shapes"
+
+    # Use nk62 name to avoid conflicts with the nuke 9+ shapes output
+    override_name = "nk62"
 
 
 class ExtractFusionShapes(ExtractNukeShapes):

--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -28,6 +28,10 @@ class PublishPluginsModel(BaseSettingsModel):
         title="Extract Nuke 9+ .nk Shapes",
         section="Extract Shapes",
     )
+    ExtractNuke62Shapes: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
+        title="Extract Nuke 6.2+ .nk Shapes",
+    )
     ExtractSilhouetteShapes: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
         title="Extract Silhouette .fxs Shapes.",
@@ -58,6 +62,11 @@ class PublishPluginsModel(BaseSettingsModel):
 DEFAULT_SILHOUETTE_PUBLISH_SETTINGS = {
     "ExtractNukeShapes": {
         "enabled": True,
+        "optional": False,
+        "active": True,
+    },
+    "ExtractNuke62Shapes": {
+        "enabled": False,
         "optional": False,
         "active": True,
     },


### PR DESCRIPTION
## Changelog Description

Add support for extracting Nuke 6.2+ shapes

## Additional review information

The nuke 6.2+ representations will be named `nk62` and have representation `outputName` set to `nk62` as well to avoid clashing names if both 9+ and 6.2+ extractors are enabled.

The 6.2 extractor is disabled by default.

## Testing notes:

1. Enabling/disabling the extractor should work.
2. Exporting both Nuke 9+ and 6.2+ shapes should work.
