### PR TITLE
Allow publishing along the `project.sfx` file as an extra representation to the workfile publish

### DIFF
--- a/client/ayon_silhouette/plugins/publish/extract_workfile.py
+++ b/client/ayon_silhouette/plugins/publish/extract_workfile.py
@@ -12,6 +12,8 @@ class SilhouetteExtractWorkfile(publish.Extractor):
     hosts = ["silhouette"]
     families = ["workfile"]
 
+    add_project_sfx = False
+
     def process(self, instance):
         """Extract the current working file as .zip"""
         # Note that Silhouette project workfiles are actually folders,
@@ -37,3 +39,15 @@ class SilhouetteExtractWorkfile(publish.Extractor):
             "files": filename,
             "stagingDir": staging_dir,
         })
+
+        if self.add_project_sfx:
+            # Add the project.sfx file as a separate representation
+            project_sfx = os.path.join(current_file, "project.sfx")
+
+            instance.data.setdefault("representations", []).append({
+                "outputName": "project",
+                "name": "sfx_project",
+                "ext": "sfx",
+                "files": os.path.basename(project_sfx),
+                "stagingDir": os.path.dirname(project_sfx),
+            })

--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -21,6 +21,17 @@ class BasicEnabledStatesModel(BaseSettingsModel):
     )
 
 
+class SilhouetteExtractWorkfileModel(BaseSettingsModel):
+    add_project_sfx: bool = SettingsField(
+        False,
+        title="Add project.sfx representation",
+        description=(
+            "Add the project.sfx file as a separate `sfx_project` "
+            "representation."
+        ),
+    )
+
+
 class PublishPluginsModel(BaseSettingsModel):
     # Shapes
     ExtractNukeShapes: BasicEnabledStatesModel = SettingsField(
@@ -56,6 +67,13 @@ class PublishPluginsModel(BaseSettingsModel):
     SilhouetteExtractNuke5Track: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
         title="Extract Nuke 5 .nk Trackers",
+    )
+
+    # Workfile
+    SilhouetteExtractWorkfile: SilhouetteExtractWorkfileModel = SettingsField(
+        default_factory=SilhouetteExtractWorkfileModel,
+        title="Extract Workfile",
+        section="Extract Workfile",
     )
 
 
@@ -94,5 +112,8 @@ DEFAULT_SILHOUETTE_PUBLISH_SETTINGS = {
         "enabled": True,
         "optional": False,
         "active": True,
+    },
+    "SilhouetteExtractWorkfile": {
+        "add_project_sfx": False,
     },
 }


### PR DESCRIPTION
## Changelog Description

Allow publishing along the `project.sfx` file as an extra representation to the workfile publish

## Additional review information

This is disabled by default and must be enabled in settings `ayon+settings://silhouette/publish/SilhouetteExtractWorkfile/add_project_sfx`

![image](https://github.com/user-attachments/assets/75003ea0-bac9-4c13-a8b5-e3e833fc5431)

Fix https://github.com/ynput/ayon-silhouette/issues/26


## Testing notes:
1. When enabled a `sfx_project` representation should also be published along which matches the `project.sfx` in the workfile folder.