### PR TITLE
Matte Shapes: Include layers in Shapes exports

### DIFF
--- a/client/ayon_silhouette/plugins/publish/extract_shapes.py
+++ b/client/ayon_silhouette/plugins/publish/extract_shapes.py
@@ -60,7 +60,6 @@ class ExtractNukeShapes(publish.Extractor,
             ]
 
         with lib.maintained_selection():
-            fx.activate(node)
             fx.select(shapes)
             with contextlib.ExitStack() as stack:
                 self.log.debug(f"Exporting '{self.io_module}' to: {path}")

--- a/client/ayon_silhouette/plugins/publish/extract_shapes.py
+++ b/client/ayon_silhouette/plugins/publish/extract_shapes.py
@@ -58,9 +58,9 @@ class ExtractNukeShapes(publish.Extractor,
                 shape for shape, _label in lib.iter_children(node)
                 if isinstance(shape, allowed_types)
             ]
-            self.log.info(shapes)
 
         with lib.maintained_selection():
+            fx.activate(node)
             fx.select(shapes)
             with contextlib.ExitStack() as stack:
                 self.log.debug(f"Exporting '{self.io_module}' to: {path}")

--- a/client/ayon_silhouette/plugins/publish/extract_shapes.py
+++ b/client/ayon_silhouette/plugins/publish/extract_shapes.py
@@ -42,11 +42,23 @@ class ExtractNukeShapes(publish.Extractor,
         shape_ids = instance.data.get("creator_attributes", {}).get("shapes")
         if shape_ids:
             shapes = [fx.findObject(shape_id) for shape_id in shape_ids]
+
+            # Include parent layers for the selected shapes, otherwise the
+            # layers will be excluded, and hence the structure will be lost
+            layers = set()
+            for shape in shapes:
+                parent = shape.parent
+                while isinstance(parent, fx.Layer):
+                    layers.add(parent)
+                    parent = parent.parent
+            shapes.extend(layers)
         else:
+            allowed_types = (fx.Shape, fx.Layer)
             shapes = [
                 shape for shape, _label in lib.iter_children(node)
-                if isinstance(shape, fx.Shape)
+                if isinstance(shape, allowed_types)
             ]
+            self.log.info(shapes)
 
         with lib.maintained_selection():
             fx.select(shapes)


### PR DESCRIPTION
## Changelog Description

Now Layers are included when exporting shapes, generating the same visual structure as you had in your silhouette project in exported `fxs` files.

## Additional review information

Layers in the object list will now be included in the output.

![image](https://github.com/user-attachments/assets/8f885f53-5229-469e-aa14-6d6c903ebb19)

Example export of the above:

[ynts_char_hero_matteshapesMain_v033.zip](https://github.com/user-attachments/files/19910300/ynts_char_hero_matteshapesMain_v033.zip)

Fix #24 

## Testing notes:
1. A scene with layers in the Roto's Object List will now be included in the exported `fxs` output
2. This should work with and without Export Shapes selected in the publisher UI.
