### PR TITLE
Matte Shapes: Fix export being empty if Roto node is not active object

### DIFF
--- a/client/ayon_silhouette/api/lib.py
+++ b/client/ayon_silhouette/api/lib.py
@@ -83,14 +83,17 @@ def collect_animation_defs(create_context, fps=False):
 
 
 @contextlib.contextmanager
-def maintained_selection():
+def maintained_selection(preserve_active_node=True):
     """Maintain selection during context."""
 
+    previous_active_node = fx.activeNode()
     previous_selection = fx.selection()
     try:
         yield
     finally:
         fx.select(previous_selection)
+        if preserve_active_node and previous_active_node:
+            fx.activate(previous_active_node)
 
 
 @contextlib.contextmanager

--- a/client/ayon_silhouette/plugins/publish/extract_shapes.py
+++ b/client/ayon_silhouette/plugins/publish/extract_shapes.py
@@ -49,6 +49,7 @@ class ExtractNukeShapes(publish.Extractor,
             ]
 
         with lib.maintained_selection():
+            fx.activate(node)
             fx.select(shapes)
             with contextlib.ExitStack() as stack:
                 self.log.debug(f"Exporting '{self.io_module}' to: {path}")

--- a/client/ayon_silhouette/plugins/publish/extract_track.py
+++ b/client/ayon_silhouette/plugins/publish/extract_track.py
@@ -49,6 +49,7 @@ class SilhouetteExtractAfterEffectsTrack(publish.Extractor,
             ]
 
         with lib.maintained_selection():
+            fx.activate(node)
             fx.select(trackers)
             with contextlib.ExitStack() as stack:
                 self.log.debug(f"Exporting '{self.io_module}' to: {path}")


### PR DESCRIPTION
## Changelog Description

Fix Exports like Matte Shapes being empty when the Roto node was not the active selected object when publishing

## Additional review information

Fix #25

## Testing notes:

1. Select a different node than the Matte Shapes Roto node, e.g. activate the Output node - then publish.
2. The generated matte shapes `.nk` and `.fxs` should not be empty AND include the correct output.
