### PR TITLE
Load Matte Shapes / Trackers: Set product name as label for new nodes

### DIFF
--- a/client/ayon_silhouette/api/plugin.py
+++ b/client/ayon_silhouette/api/plugin.py
@@ -283,6 +283,8 @@ class SilhouetteImportLoader(SilhouetteLoader):
             fx.activeSession().addNode(node)
             lib.set_new_node_position(node)
 
+            # Label the newly generated using the product name
+            node.label = context["product"]["name"]
 
         # Import the file
         fx.activate(node)


### PR DESCRIPTION
## Changelog Description

Label newly loaded Matte Shapes or Tracker Points nodes using the product name

## Additional review information

Fix #22

## Testing notes:

1. Loading matte shapes (without any active selection), then when it generates the new node on load it should be named similar to the Product Name so that it's instantly clear which is the newly loaded node and can be easily identifier over other nodes in the tree.
