### PR TITLE
Chore: Don't use deprecated workfile method

### DIFF
--- a/client/ayon_silhouette/plugins/publish/increment_current_file.py
+++ b/client/ayon_silhouette/plugins/publish/increment_current_file.py
@@ -26,7 +26,7 @@ class IncrementCurrentFile(pyblish.api.ContextPlugin,
 
         # Filename must not have changed since collecting
         host = registered_host()
-        current_file = host.current_file()
+        current_file = host.get_current_workfile()
         if context.data["currentFile"] != current_file:
             raise KnownPublishError(
                 "Collected filename mismatches from current scene name."


### PR DESCRIPTION
## Changelog Description
Use `get_current_workfile` instead of `current_workfile`.

## Additional review information
Method `current_workfile` is deprecated for years now.

## Testing notes:
1. Increment current file should work.
