### PR TITLE
Allow to set session frame range on load of SourceLoader

### DIFF
--- a/client/ayon_silhouette/plugins/load/load_source.py
+++ b/client/ayon_silhouette/plugins/load/load_source.py
@@ -124,7 +124,10 @@ class SourceLoader(plugin.SilhouetteLoader):
 
         # Get the start frame from the loaded product
         lookup_entities = [
-            context["representation"],
+            # TODO: Allow taking from representation if it actually contains
+            #  more sensible data. Currently it seems to just contain the
+            #  task frame ranges by default?
+            # context["representation"],
             context["version"]
         ]
         attrs = {"frameStart", "frameEnd", "handleStart", "handleEnd"}

--- a/server/settings/load.py
+++ b/server/settings/load.py
@@ -1,0 +1,28 @@
+from ayon_server.settings import BaseSettingsModel, SettingsField
+
+
+class SourceLoaderModel(BaseSettingsModel):
+    set_start_frame_on_load: bool = SettingsField(
+        default=False,
+        title="Set Start Frame on Load",
+        description=(
+            "When loading a source, set the active session's start frame to "
+            "the start frame of the loaded source. This may be helpful "
+            "because Silhouette aligns loaded sources with the start frame of "
+            "the session."
+        ),
+    )
+
+class LoadPluginsModel(BaseSettingsModel):
+    # Shapes
+    SourceLoader: SourceLoaderModel = SettingsField(
+        default_factory=SourceLoaderModel,
+        title="Load Source",
+    )
+
+
+DEFAULT_SILHOUETTE_LOAD_SETTINGS = {
+    "SourceLoader": {
+        "set_start_frame_on_load": False,
+    }
+}

--- a/server/settings/load.py
+++ b/server/settings/load.py
@@ -2,14 +2,14 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
 class SourceLoaderModel(BaseSettingsModel):
-    set_start_frame_on_load: bool = SettingsField(
+    set_session_frame_range_on_load: bool = SettingsField(
         default=False,
-        title="Set Start Frame on Load",
+        title="Set Session Frame Range on Load",
         description=(
-            "When loading a source, set the active session's start frame to "
-            "the start frame of the loaded source. This may be helpful "
-            "because Silhouette aligns loaded sources with the start frame of "
-            "the session."
+            "When loading a source, set the active session's start frame and "
+            "duration to the frame range of the loaded source. This may be "
+            "helpful because Silhouette aligns loaded sources with the start "
+            "frame of the session."
         ),
     )
 
@@ -23,6 +23,6 @@ class LoadPluginsModel(BaseSettingsModel):
 
 DEFAULT_SILHOUETTE_LOAD_SETTINGS = {
     "SourceLoader": {
-        "set_start_frame_on_load": False,
+        "set_session_frame_range_on_load": False,
     }
 }

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -4,11 +4,16 @@ from .templated_workfile_build import (
     TemplatedWorkfileBuildModel
 )
 from .publish import PublishPluginsModel, DEFAULT_SILHOUETTE_PUBLISH_SETTINGS
+from .load import LoadPluginsModel, DEFAULT_SILHOUETTE_LOAD_SETTINGS
 
 class SilhouetteSettings(BaseSettingsModel):
     imageio: ImageIOSettings = SettingsField(
         default_factory=ImageIOSettings,
         title="Color Management (ImageIO)"
+    )
+    load: LoadPluginsModel = SettingsField(
+        title="Load",
+        default_factory=LoadPluginsModel
     )
     publish: PublishPluginsModel = SettingsField(
         title="Publish",
@@ -22,6 +27,7 @@ class SilhouetteSettings(BaseSettingsModel):
 
 DEFAULT_VALUES = {
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
+    "load": DEFAULT_SILHOUETTE_LOAD_SETTINGS,
     "publish": DEFAULT_SILHOUETTE_PUBLISH_SETTINGS,
     "templated_workfile_build": {
         "profiles": []


### PR DESCRIPTION
## Changelog Description

Allow to session frame range on load of SourceLoader

## Additional review information

1. Adds load source option box to define whether to set start frame on load or not.

![image](https://github.com/user-attachments/assets/8b983b34-5a42-4a2a-b71c-8bf725b6d427)

![image](https://github.com/user-attachments/assets/e8f4c2f5-546c-4a54-a5c4-ca0e9be6f600)


3. Also adds setting `ayon+settings://silhouette/load/SourceLoader/set_start_frame_on_load` to set the default behavior

![image](https://github.com/user-attachments/assets/40816f30-5060-4e41-8cad-f4cb6e10ae2d)

Fix #34

## Testing notes:

1. Loader should still work.