### PR TITLE
Load all parts of a source when loading, so that both L an R are loaded for stereo EXRs

### DIFF
--- a/client/ayon_silhouette/plugins/load/load_source.py
+++ b/client/ayon_silhouette/plugins/load/load_source.py
@@ -4,6 +4,7 @@ import clique
 from ayon_silhouette.api import plugin, lib
 
 from ayon_core.pipeline import Anatomy
+from ayon_core.lib import BoolDef
 from ayon_core.lib.transcoding import (
     VIDEO_EXTENSIONS, IMAGE_EXTENSIONS
 )
@@ -22,6 +23,17 @@ class SourceLoader(plugin.SilhouetteLoader):
         ext.lstrip(".") for ext in VIDEO_EXTENSIONS.union(IMAGE_EXTENSIONS)
     }
 
+    @classmethod
+    def get_options(cls, contexts):
+        return [
+            BoolDef(
+                "load_all_parts",
+                label="Load All Parts",
+                default=True,
+                tooltip="Load all parts of the source, "
+                        "not just the first one."),
+        ]
+
     @lib.undo_chunk("Load Source")
     def load(self, context, name=None, namespace=None, options=None):
         project = fx.activeProject()
@@ -30,28 +42,43 @@ class SourceLoader(plugin.SilhouetteLoader):
 
         filepath = self.filepath_from_context(context)
 
-        # Add Source item to the project
-        source = fx.Source(filepath)
+        # A source file may contain multiple parts, such as a left view
+        # and a right view in a single EXR.
+        options = options or {}
+        load_all_parts = options.get("load_all_parts", True)
 
-        # Provide a nice label indicating the product
-        source.label = self._get_label(context)
-        project.addItem(source)
+        has_multiple_parts = os.path.splitext(filepath)[-1].lower() in {
+            ".exr", ".sxr"
+        } and fx.Source(filepath, part=1).video
 
-        # property.hidden = True  # hide the attribute
-        lib.imprint(source, data={
-            "name": str(name),
-            "namespace": str(namespace),
-            "loader": str(self.__class__.__name__),
-            "representation": context["representation"]["id"],
-        })
+        part = 0
+        while True:
+            source = fx.Source(filepath, part=part)
 
-        # container = pipeline.containerise(
-        #     name=str(name),
-        #     namespace=str(namespace),
-        #     nodes=nodes,
-        #     context=context,
-        #     loader=str(self.__class__.__name__),
-        # )
+            # Check whether the chosen part has any video or audio, if not
+            # we assume the part does not exist and we stop loading.
+            if not source.video and not source.audio:
+                if part == 0:
+                    self.log.warning("Loaded source has no video or audio.")
+                break
+
+            # Provide a nice label indicating the product
+            source.label = self._get_label(context)
+            project.addItem(source)
+
+            # property.hidden = True  # hide the attribute
+            lib.imprint(source, data={
+                "name": str(name),
+                "namespace": str(namespace),
+                "loader": str(self.__class__.__name__),
+                "representation": context["representation"]["id"],
+            })
+
+            if not has_multiple_parts or not load_all_parts:
+                # Never load more than one part
+                break
+
+            part += 1
 
     def filepath_from_context(self, context):
         # If the media is a sequence of files we need to load it with the


### PR DESCRIPTION
## Changelog Description

Load all parts of a source when loading, so that both L an R are loaded for stereo EXRs

## Additional review information

Fix #27 
More info also see: https://forum.borisfx.com/t/python-load-both-channels-of-stereo-exr-sxr/20215

## Testing notes:

1. Loading sources should work as intended.
2. Loading SXR should be able to load the individual parts.