### PR TITLE
Publish: Use new workfiles API to increment current workfile.

### DIFF
--- a/client/ayon_silhouette/api/pipeline.py
+++ b/client/ayon_silhouette/api/pipeline.py
@@ -20,10 +20,7 @@ from ayon_core.pipeline import (
 )
 from ayon_core.pipeline.load import any_outdated_containers
 from ayon_core.lib import emit_event, register_event_callback
-from ayon_core.pipeline.context_tools import (
-    version_up_current_workfile,
-    get_current_task_entity
-)
+from ayon_core.pipeline.context_tools import get_current_task_entity
 from ayon_core.settings import get_current_project_settings
 from ayon_core.tools.workfile_template_build import open_template_ui
 from . import lib
@@ -33,6 +30,14 @@ from .workfile_template_builder import (
     update_placeholder,
     build_workfile_template,
 )
+
+# Function 'save_next_version' was introduced in ayon-core 1.5.0
+try:
+    from ayon_core.pipeline.workfile import save_next_version
+except ImportError:
+    from ayon_core.pipeline.context_tools import (
+        version_up_current_workfile as save_next_version
+    )
 
 import fx
 import hook
@@ -111,7 +116,7 @@ class SilhouetteHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             if project_settings["core"]["tools"]["ayon_menu"].get(
                 "version_up_current_workfile"):
                     action = menu.addAction("Version Up Workfile")
-                    action.triggered.connect(version_up_current_workfile)
+                    action.triggered.connect(save_next_version)
         except KeyError:
             print("Version Up Workfile setting not found in "
                   "Core Settings. Please update Core Addon")

--- a/client/ayon_silhouette/plugins/publish/increment_current_file.py
+++ b/client/ayon_silhouette/plugins/publish/increment_current_file.py
@@ -1,6 +1,9 @@
+import os
+
 import pyblish.api
 
 from ayon_core.lib import version_up
+from ayon_core.host import IWorkfileHost
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.publish import (
     KnownPublishError,
@@ -24,13 +27,37 @@ class IncrementCurrentFile(pyblish.api.ContextPlugin,
         if not self.is_active(context.data):
             return
 
-        # Filename must not have changed since collecting
+        # Filename must not have changed since collecting.
         host = registered_host()
-        current_file = host.get_current_workfile()
-        if context.data["currentFile"] != current_file:
+        current_filepath: str = host.get_current_workfile()
+        if context.data["currentFile"] != current_filepath:
             raise KnownPublishError(
-                "Collected filename mismatches from current scene name."
+                f"Collected filename '{context.data['currentFile']}' differs"
+                f" from current scene name '{current_filepath}'."
             )
 
-        new_filepath = version_up(current_file)
-        host.save_workfile(new_filepath)
+        try:
+            from ayon_core.pipeline.workfile import save_next_version
+            from ayon_core.host.interfaces import SaveWorkfileOptionalData
+
+            current_filename = os.path.basename(current_filepath)
+            save_next_version(
+                description=(
+                    f"Incremented by publishing from {current_filename}"
+                ),
+                # Optimize the save by reducing needed queries for context
+                prepared_data=SaveWorkfileOptionalData(
+                    project_entity=context.data["projectEntity"],
+                    project_settings=context.data["project_settings"],
+                    anatomy=context.data["anatomy"],
+                )
+            )
+        except ImportError:
+            # Backwards compatibility before ayon-core 1.5.0
+            self.log.debug(
+                "Using legacy `version_up`. Update AYON core addon to "
+                "use newer `save_next_version` function."
+            )
+            new_filepath = version_up(current_filepath)
+            host: IWorkfileHost = registered_host()
+            host.save_workfile(new_filepath)


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

Test with ayon-core 1.5.0 (and also backwards compatibility against older releases)

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
5. Publishing should also still work and increment (the old way) with older ayon-core.
