### PR TITLE
Chore: Define host name in package.py

### DIFF
--- a/package.py
+++ b/package.py
@@ -11,6 +11,7 @@ version = "0.1.4+dev"
 # Name of client code directory imported in AYON launcher
 # - do not specify if there is no client code
 client_dir = "ayon_silhouette"
+app_host_name = "silhouette"
 
 # Version compatibility with AYON server
 ayon_server_version = ">=1.1.2"


### PR DESCRIPTION
## Changelog Description
Addon definition in package.py is missing `app_host_name` for host name definition.

## Additional review information
Missing host name means that it would not be shown in hosts enum in settings.

## Testing notes:
1. Validate changes made.
