### PR TITLE
Allow session frame range to always be set on source update as well and fix timeline to update with session frame range changes

### DIFF
--- a/client/ayon_silhouette/api/lib.py
+++ b/client/ayon_silhouette/api/lib.py
@@ -242,8 +242,10 @@ def set_frame_range_from_entity(session, task_entity):
 
     with undo_chunk("Set session frame range"):
         session.frameRate = fps
-        session.startFrame = frame_start
+        # Set the duration before startFrame otherwise the viewer timeline
+        # will not update correctly, see: https://forum.borisfx.com/t/20386
         session.duration = (frame_end - frame_start) + 1
+        session.startFrame = frame_start
 
 
 def set_bit_depth_from_settings(session, project_settings: dict):

--- a/client/ayon_silhouette/api/pipeline.py
+++ b/client/ayon_silhouette/api/pipeline.py
@@ -463,6 +463,7 @@ def _on_set_frame_range():
     task_entity = get_current_task_entity()
     lib.set_frame_range_from_entity(session, task_entity)
 
+
 def _generate_default_session():
     """Create a project and session using the current context task attributes.
 

--- a/client/ayon_silhouette/api/pipeline.py
+++ b/client/ayon_silhouette/api/pipeline.py
@@ -463,7 +463,6 @@ def _on_set_frame_range():
     task_entity = get_current_task_entity()
     lib.set_frame_range_from_entity(session, task_entity)
 
-
 def _generate_default_session():
     """Create a project and session using the current context task attributes.
 

--- a/server/settings/load.py
+++ b/server/settings/load.py
@@ -12,6 +12,14 @@ class SourceLoaderModel(BaseSettingsModel):
             "frame of the session."
         ),
     )
+    set_session_frame_range_on_update: bool = SettingsField(
+        default=False,
+        title="Set Session Frame Range on Update",
+        description=(
+            "When updating a source, force the active session's start frame "
+            "and duration to the frame range of the loaded source."
+        ),
+    )
 
 class LoadPluginsModel(BaseSettingsModel):
     # Shapes
@@ -24,5 +32,6 @@ class LoadPluginsModel(BaseSettingsModel):
 DEFAULT_SILHOUETTE_LOAD_SETTINGS = {
     "SourceLoader": {
         "set_session_frame_range_on_load": False,
+        "set_session_frame_range_on_update": False,
     }
 }


### PR DESCRIPTION
## Changelog Description

Allow session frame range to always be set on source update as well and fix timeline to update with session frame range changes, also see: https://forum.borisfx.com/t/20386

## Additional review information

This is a replacement and simpler brute force hammer for what https://github.com/ynput/ayon-silhouette/pull/40 is trying to solve. Essentially, whenever we load/update source the client wants the session start and duration to match the source. Just so that the frame range Silhouette plays at is 1:1 match. Why not use the time shift technique from that PR? Because it's confusing the Silhouette users - the artist sees the time shift on the source and gets scared that somehow, he shifted it accidentally even though it's really "fixing" the Silhouette behavior. To avoid that confusion, this PR instead takes a big hammer 🔨 and just enforces the Silhouette session to match the source's frame range.

## Testing notes:

1. Enable in settings:
<img width="348" height="167" alt="image" src="https://github.com/user-attachments/assets/8358cae3-1b5f-40cf-a830-767c7b442b03" />
```
ayon+settings://silhouette/load/SourceLoader/set_session_frame_range_on_load
ayon+settings://silhouette/load/SourceLoader/set_session_frame_range_on_update
```

2. Loading a source and updating a source should "set the current session's frame range" to match the source.

Note that AYON > Set Frame Range should still be setting the Session frame range according to the AYON Task data.