### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_silhouette/plugins/create/create_workfile.py
+++ b/client/ayon_silhouette/plugins/create/create_workfile.py
@@ -39,12 +39,12 @@ class CreateWorkfile(AutoCreator):
         variant = self.default_variant
         if not workfile_instance:
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                variant,
-                host_name,
-                project_entity=project_entity
+                project_name=project_name,
+                project_entity=project_entity,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=variant,
+                host_name=host_name,
             )
             data = {
                 "folderPath": folder_path,
@@ -74,13 +74,13 @@ class CreateWorkfile(AutoCreator):
         ):
             # Update instance context if it's different
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                variant,
-                host_name,
+                project_name=project_name,
+                project_entity=project_entity,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=variant,
+                host_name=host_name,
                 instance=workfile_instance,
-                project_entity=project_entity
             )
 
             workfile_instance["folderPath"] = folder_path


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
