### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_silhouette/plugins/create/create_matte_shapes.py
+++ b/client/ayon_silhouette/plugins/create/create_matte_shapes.py
@@ -11,6 +11,7 @@ class CreateMatteShapes(plugin.SilhouetteCreator):
     label = "Matte Shapes"
     description = __doc__
     product_type = "matteshapes"
+    product_base_type = "matteshapes"
     icon = "cubes"
 
     create_node_type = "RotoNode"

--- a/client/ayon_silhouette/plugins/create/create_render.py
+++ b/client/ayon_silhouette/plugins/create/create_render.py
@@ -11,6 +11,7 @@ class CreateRender(plugin.SilhouetteCreator):
     label = "Render"
     description = __doc__
     product_type = "render"
+    product_base_type = "render"
     icon = "eye"
 
     def create(self, product_name, instance_data, pre_create_data):

--- a/client/ayon_silhouette/plugins/create/create_track_points.py
+++ b/client/ayon_silhouette/plugins/create/create_track_points.py
@@ -11,6 +11,7 @@ class CreateTrackPoints(plugin.SilhouetteCreator):
     label = "Track Points"
     description = __doc__
     product_type = "trackpoints"
+    product_base_type = "trackpoints"
     icon = "cubes"
 
     create_node_type = "TrackerNode"

--- a/client/ayon_silhouette/plugins/create/create_workfile.py
+++ b/client/ayon_silhouette/plugins/create/create_workfile.py
@@ -10,6 +10,7 @@ class CreateWorkfile(AutoCreator):
     identifier = "io.ayon.creators.silhouette.workfile"
     label = "Workfile"
     product_type = "workfile"
+    product_base_type = "workfile"
     icon = "fa5.file"
 
     project_property_name = "AYON_workfile"


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.