### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_silhouette/api/plugin.py
+++ b/client/ayon_silhouette/api/plugin.py
@@ -67,8 +67,9 @@ class SilhouetteCreator(Creator):
     exporting e.g. track points and matte shapes from the same RotoNode.
 
     """
-    default_variants = ["Main"]
+    skip_discovery = True
     settings_category = "silhouette"
+    default_variants = ["Main"]
 
     create_node_type = "OutputNode"
 

--- a/client/ayon_silhouette/api/plugin.py
+++ b/client/ayon_silhouette/api/plugin.py
@@ -63,8 +63,8 @@ class SilhouetteCreator(Creator):
     as `{node_id}|{uuid}`.
 
     This way, a single RotoNode can have multiple instances of different
-    product types (or even the same product type) to allow exporting e.g.
-    track points and matte shapes from the same RotoNode.
+    product base types (or even the same product base type) to allow
+    exporting e.g. track points and matte shapes from the same RotoNode.
 
     """
     default_variants = ["Main"]
@@ -129,8 +129,12 @@ class SilhouetteCreator(Creator):
         instance_data["instance_id"] = instance_id
         instance_data["label"] = self._define_label(
             instance_node, product_name)
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         instance = CreatedInstance(
-            product_type=self.product_type,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
             product_name=product_name,
             data=instance_data,
             creator=self,

--- a/client/ayon_silhouette/plugins/create/create_matte_shapes.py
+++ b/client/ayon_silhouette/plugins/create/create_matte_shapes.py
@@ -10,8 +10,8 @@ class CreateMatteShapes(plugin.SilhouetteCreator):
     identifier = "io.ayon.creators.silhouette.matteshapes"
     label = "Matte Shapes"
     description = __doc__
-    product_type = "matteshapes"
     product_base_type = "matteshapes"
+    product_type = product_base_type
     icon = "cubes"
 
     create_node_type = "RotoNode"

--- a/client/ayon_silhouette/plugins/create/create_matte_shapes.py
+++ b/client/ayon_silhouette/plugins/create/create_matte_shapes.py
@@ -1,10 +1,11 @@
 import fx
 
 from ayon_core.lib import EnumDef
-from ayon_silhouette.api import plugin, lib
+from ayon_silhouette.api import lib
+from ayon_silhouette.api.plugin import SilhouetteCreator
 
 
-class CreateMatteShapes(plugin.SilhouetteCreator):
+class CreateMatteShapes(SilhouetteCreator):
     """Matte Shapes"""
 
     identifier = "io.ayon.creators.silhouette.matteshapes"

--- a/client/ayon_silhouette/plugins/create/create_render.py
+++ b/client/ayon_silhouette/plugins/create/create_render.py
@@ -1,10 +1,8 @@
-from ayon_silhouette.api import (
-    lib,
-    plugin
-)
+from ayon_silhouette.api import lib
+from ayon_silhouette.api.plugin import SilhouetteCreator
 
 
-class CreateRender(plugin.SilhouetteCreator):
+class CreateRender(SilhouetteCreator):
     """Render Output"""
 
     identifier = "io.ayon.creators.silhouette.render"

--- a/client/ayon_silhouette/plugins/create/create_render.py
+++ b/client/ayon_silhouette/plugins/create/create_render.py
@@ -10,8 +10,8 @@ class CreateRender(plugin.SilhouetteCreator):
     identifier = "io.ayon.creators.silhouette.render"
     label = "Render"
     description = __doc__
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "eye"
 
     def create(self, product_name, instance_data, pre_create_data):

--- a/client/ayon_silhouette/plugins/create/create_track_points.py
+++ b/client/ayon_silhouette/plugins/create/create_track_points.py
@@ -10,8 +10,8 @@ class CreateTrackPoints(plugin.SilhouetteCreator):
     identifier = "io.ayon.creators.silhouette.trackpoints"
     label = "Track Points"
     description = __doc__
-    product_type = "trackpoints"
     product_base_type = "trackpoints"
+    product_type = product_base_type
     icon = "cubes"
 
     create_node_type = "TrackerNode"

--- a/client/ayon_silhouette/plugins/create/create_track_points.py
+++ b/client/ayon_silhouette/plugins/create/create_track_points.py
@@ -1,10 +1,11 @@
 import fx
 
 from ayon_core.lib import EnumDef
-from ayon_silhouette.api import plugin, lib
+from ayon_silhouette.api import lib
+from ayon_silhouette.api.plugin import SilhouetteCreator
 
 
-class CreateTrackPoints(plugin.SilhouetteCreator):
+class CreateTrackPoints(SilhouetteCreator):
     """Track Points"""
 
     identifier = "io.ayon.creators.silhouette.trackpoints"

--- a/client/ayon_silhouette/plugins/create/create_workfile.py
+++ b/client/ayon_silhouette/plugins/create/create_workfile.py
@@ -9,8 +9,8 @@ class CreateWorkfile(AutoCreator):
     """Workfile auto-creator."""
     identifier = "io.ayon.creators.silhouette.workfile"
     label = "Workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     icon = "fa5.file"
 
     project_property_name = "AYON_workfile"

--- a/client/ayon_silhouette/plugins/create/create_workfile.py
+++ b/client/ayon_silhouette/plugins/create/create_workfile.py
@@ -65,7 +65,11 @@ class CreateWorkfile(AutoCreator):
             )
             self.log.info("Auto-creating workfile instance...")
             workfile_instance = CreatedInstance(
-                self.product_type, product_name, data, self
+                product_base_type=self.product_base_type,
+                product_type=self.product_base_type,
+                product_name=product_name,
+                data=data,
+                creator=self,
             )
             self._add_instance_to_context(workfile_instance)
 

--- a/client/ayon_silhouette/plugins/load/actions.py
+++ b/client/ayon_silhouette/plugins/load/actions.py
@@ -28,7 +28,7 @@ def _set_frame_range(frame_start: int, frame_end: int, fps: float):
 class SetFrameRangeLoader(load.LoaderPlugin):
     """Set frame range excluding pre- and post-handles"""
 
-    product_types = {
+    product_base_types = {
         "animation",
         "camera",
         "pointcache",
@@ -39,6 +39,7 @@ class SetFrameRangeLoader(load.LoaderPlugin):
         "mayaScene",
         "review"
     }
+    product_types = product_base_types
     representations = {"*"}
 
     label = "Set frame range"
@@ -66,7 +67,7 @@ class SetFrameRangeLoader(load.LoaderPlugin):
 class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
     """Set frame range including pre- and post-handles"""
 
-    product_types = {
+    product_base_types = {
         "animation",
         "camera",
         "pointcache",
@@ -77,6 +78,7 @@ class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
         "mayaScene",
         "review"
     }
+    product_types = product_base_types
     representations = {"*"}
 
     label = "Set frame range (with handles)"

--- a/client/ayon_silhouette/plugins/load/load_shapes.py
+++ b/client/ayon_silhouette/plugins/load/load_shapes.py
@@ -4,7 +4,8 @@ from ayon_silhouette.api import plugin
 class ShapesLoader(plugin.SilhouetteImportLoader):
 
     color = "orange"
-    product_types = {"matteshapes"}
+    product_base_types = {"matteshapes"}
+    product_types = product_base_types
     icon = "code-fork"
     label = "Load Shapes"
     order = -5

--- a/client/ayon_silhouette/plugins/load/load_source.py
+++ b/client/ayon_silhouette/plugins/load/load_source.py
@@ -21,7 +21,8 @@ class SourceLoader(plugin.SilhouetteLoader):
     """Load media source."""
 
     color = "orange"
-    product_types = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     icon = "code-fork"
     label = "Load Source"
     order = -10

--- a/client/ayon_silhouette/plugins/load/load_trackpoints.py
+++ b/client/ayon_silhouette/plugins/load/load_trackpoints.py
@@ -5,7 +5,8 @@ class TrackPointsLoader(plugin.SilhouetteImportLoader):
     """Load track points."""
 
     color = "orange"
-    product_types = {"trackpoints"}
+    product_base_types = {"trackpoints"}
+    product_types = product_base_types
     icon = "code-fork"
     label = "Load Trackers"
     order = -5

--- a/package.py
+++ b/package.py
@@ -22,7 +22,7 @@ ayon_server_version = ">=1.1.2"
 # Mapping of addon name to version requirements
 # - addon with specified version range must exist to be able to use this addon
 ayon_required_addons = {
-    "core": ">1.0.14",
+    "core": ">=1.8.0",
 }
 # Mapping of addon name to version requirements
 # - if addon is used in same bundle the version range must be valid

--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -8,6 +8,7 @@ class ProductTypeItemModel(BaseSettingsModel):
         description="Product type name",
     )
     label: str = SettingsField(
+        "",
         title="Label",
         description="Label to display in UI for the product type",
     )

--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -1,0 +1,38 @@
+from ayon_server.settings import BaseSettingsModel, SettingsField
+
+
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name",
+    )
+    label: str = SettingsField(
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
+
+
+class CreatePluginModel(BaseSettingsModel):
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
+    )
+
+
+class CreatePluginsModel(BaseSettingsModel):
+    CreateMatteShapes: CreatePluginModel = SettingsField(
+        title="Matte Shapes",
+        description="Create Matte Shapes plugin settings.",
+    )
+    CreateRender: CreatePluginModel = SettingsField(
+        title="Render",
+        description="Create Render plugin settings.",
+    )
+    CreateTrackPoints: CreatePluginModel = SettingsField(
+        title="Track Points",
+        description="Create Track Points plugin settings.",
+    )

--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -4,6 +4,7 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 class ProductTypeItemModel(BaseSettingsModel):
     _layout = "compact"
     product_type: str = SettingsField(
+        "",
         title="Product type",
         description="Product type name",
     )
@@ -15,6 +16,10 @@ class ProductTypeItemModel(BaseSettingsModel):
 
 
 class CreatePluginModel(BaseSettingsModel):
+    enabled: bool = SettingsField(
+        True,
+        title="Enabled",
+    )
     product_type_items: list[ProductTypeItemModel] = SettingsField(
         default_factory=list,
         title="Product type items",
@@ -37,3 +42,19 @@ class CreatePluginsModel(BaseSettingsModel):
         title="Track Points",
         description="Create Track Points plugin settings.",
     )
+
+
+DEFAULT_SILHOUETTE_CREATE_SETTINGS = {
+    "CreateMatteShapes": {
+        "enabled": True,
+        "product_type_items": [],
+    },
+    "CreateRender": {
+        "enabled": True,
+        "product_type_items": [],
+    },
+    "CreateTrackPoints": {
+        "enabled": True,
+        "product_type_items": [],
+    },
+}

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -8,6 +8,7 @@ from .imageio import ImageIOSettings, DEFAULT_IMAGEIO_SETTINGS
 from .templated_workfile_build import (
     TemplatedWorkfileBuildModel
 )
+from .create import CreatePluginsModel
 from .publish import PublishPluginsModel, DEFAULT_SILHOUETTE_PUBLISH_SETTINGS
 from .load import LoadPluginsModel, DEFAULT_SILHOUETTE_LOAD_SETTINGS
 
@@ -28,6 +29,10 @@ class SilhouetteSettings(BaseSettingsModel):
     load: LoadPluginsModel = SettingsField(
         title="Load",
         default_factory=LoadPluginsModel
+    )
+    create: CreatePluginsModel = SettingsField(
+        title="Create",
+        default_factory=CreatePluginsModel
     )
     publish: PublishPluginsModel = SettingsField(
         title="Publish",

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -8,7 +8,7 @@ from .imageio import ImageIOSettings, DEFAULT_IMAGEIO_SETTINGS
 from .templated_workfile_build import (
     TemplatedWorkfileBuildModel
 )
-from .create import CreatePluginsModel
+from .create import CreatePluginsModel, DEFAULT_SILHOUETTE_CREATE_SETTINGS
 from .publish import PublishPluginsModel, DEFAULT_SILHOUETTE_PUBLISH_SETTINGS
 from .load import LoadPluginsModel, DEFAULT_SILHOUETTE_LOAD_SETTINGS
 
@@ -49,6 +49,7 @@ DEFAULT_VALUES = {
     "session": DEFAULT_SILHOUETTE_SESSION_SETTINGS,
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
     "load": DEFAULT_SILHOUETTE_LOAD_SETTINGS,
+    "create": DEFAULT_SILHOUETTE_CREATE_SETTINGS,
     "publish": DEFAULT_SILHOUETTE_PUBLISH_SETTINGS,
     "templated_workfile_build": {
         "profiles": []


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Workfiles created with this PR cannot be used with older version of silhouette addon (product types are used)!!!

Codebase of silhouette is fully using product base type as "pipeline" type and product type as an alias. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

## Testing notes:
### Basics
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Existing workfiles should load up and should be possible to publish.
3. Creating new instances should work as expected.

### Product types
1. Define product types for a create plugin.
2. Create an instance with the product type.
3. Product name should use the product type in name (if template defines that).
4. Publish the instance.
5. Loader tool should show the product type and product base type in UI.