### PR TITLE
Render: Set the frames argument to `render` to ensure correct frame ranges render

### DIFF
--- a/client/ayon_silhouette/plugins/publish/extract_render.py
+++ b/client/ayon_silhouette/plugins/publish/extract_render.py
@@ -37,7 +37,7 @@ class SilhouetteExtractRender(publish.Extractor):
                 "session": session,
                 "nodes": [output_node],
                 # Override frame range
-                # "frames": list(range(start, end+1))
+                "frames": list(range(start, end+1))
             },
             progress=get_progress_handler()
         )

--- a/client/ayon_silhouette/plugins/publish/extract_render.py
+++ b/client/ayon_silhouette/plugins/publish/extract_render.py
@@ -37,7 +37,7 @@ class SilhouetteExtractRender(publish.Extractor):
                 "session": session,
                 "nodes": [output_node],
                 # Override frame range
-                "frames": list(range(start, end+1))
+                "frames": list(range(start, end + 1))
             },
             progress=get_progress_handler()
         )
@@ -52,7 +52,7 @@ class SilhouetteExtractRender(publish.Extractor):
         # Collect all rendered outputs
         filepaths = []
         for output in outputs:
-            for frame in range(start, end+1):
+            for frame in range(start, end + 1):
                 filepath = output.buildPath(frame)
                 filepaths.append(filepath)
 


### PR DESCRIPTION
## Changelog Description

Render: Set the frames argument to `render` to ensure correct frame ranges render

## Additional review information

Not entirely sure why this line was commented out to begin with though.

## Testing notes:

1. Renders should work as intended with frame ranges