### PR TITLE
Add configurable shortcuts to AYON tools from AYON settings

### DIFF
--- a/client/ayon_silhouette/api/pipeline.py
+++ b/client/ayon_silhouette/api/pipeline.py
@@ -20,8 +20,10 @@ from ayon_core.pipeline import (
 )
 from ayon_core.pipeline.load import any_outdated_containers
 from ayon_core.lib import emit_event, register_event_callback
-from ayon_core.pipeline.context_tools import get_current_task_entity
-from ayon_core.settings import get_current_project_settings
+from ayon_core.pipeline.context_tools import (
+    get_current_task_entity,
+    get_current_project_settings
+)
 from ayon_core.tools.workfile_template_build import open_template_ui
 from . import lib
 from .workfile_template_builder import (
@@ -84,14 +86,18 @@ class SilhouetteHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         # register_inventory_action_path(INVENTORY_PATH)
         register_workfile_build_plugin_path(WORKFILE_BUILD_PATH)
 
-        defer(self._install_menu)
+        project_settings = get_current_project_settings()
+
+        if fx.gui:
+            defer(partial(self._install_menu, project_settings))
+            defer(partial(self._install_shortcuts, project_settings),
+                  timeout=500)
         self._install_hooks()
 
         register_event_callback("open", on_open)
         register_event_callback("init", on_init)
 
-    def _install_menu(self):
-        project_settings = get_current_project_settings()
+    def _install_menu(self, project_settings: dict):
         parent = lib.get_main_window()
 
         menu_label = os.environ.get("AYON_MENU_LABEL") or "AYON"
@@ -200,6 +206,31 @@ class SilhouetteHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         action.triggered.connect(
             lambda: host_tools.show_experimental_tools_dialog(parent=parent)
         )
+
+    def _install_shortcuts(self, project_settings: dict):
+        parent = lib.get_main_window()
+        shortcuts = project_settings["silhouette"]["ayon_menu"]["shortcuts"]
+
+        fn = {
+            "create": lambda: host_tools.show_publisher(parent=parent,
+                                                        tab="create"),
+            "publish": lambda: host_tools.show_publisher(parent=parent,
+                                                         tab="publish"),
+            "load": lambda: host_tools.show_loader(parent=parent,
+                                                   use_context=True),
+            "manage": lambda: host_tools.show_scene_inventory(parent=parent),
+            "build_workfile": build_workfile_template,
+            "workfiles": lambda: host_tools.show_workfiles(parent=parent),
+            "version_up_workfile": save_next_version,
+        }
+
+        for key, shortcut in shortcuts.items():
+            if not shortcut:
+                # No shortcut assigned
+                continue
+            callback = fn[key]
+            self.log.debug("Installing '%s' shortcut: %s", key, shortcut)
+            fx.bind(shortcut, callback)
 
     def _install_hooks(self):
         # Connect events

--- a/server/settings/ayon_menu.py
+++ b/server/settings/ayon_menu.py
@@ -1,6 +1,17 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
+class MenuShortcuts(BaseSettingsModel):
+    """Silhouette AYON tool shortcuts."""
+    create: str = SettingsField("", title="Create...")
+    publish: str = SettingsField("", title="Publish...")
+    load: str = SettingsField("", title="Load...")
+    manage: str = SettingsField("", title="Manage...")
+    workfiles: str = SettingsField("", title="Workfiles...")
+    build_workfile: str = SettingsField("", title="Build Workfile...")
+    version_up_workfile: str = SettingsField("", title="Version Up Workfile")
+
+
 class AyonMenuSettingsModel(BaseSettingsModel):
     """Customize top AYON menu in Silhouette."""
     set_frame_range: bool = SettingsField(
@@ -18,9 +29,22 @@ class AyonMenuSettingsModel(BaseSettingsModel):
             "Set active Session resolution to match current task context."
         ),
     )
+    shortcuts: MenuShortcuts = SettingsField(
+        default_factory=MenuShortcuts,
+        title="Shortcuts",
+    )
 
 
 DEFAULT_SILHOUETTE_AYON_MENU_SETTINGS = {
     "set_frame_range": True,
     "set_resolution": True,
+    "shortcuts": {
+        "create": "ctrl+alt+c",
+        "publish": "ctrl+alt+p",
+        "load": "ctrl+alt+l",
+        "manage": "ctrl+alt+m",
+        "build_workfile": "ctrl+alt+b",
+        "workfiles": "",
+        "version_up_workfile": "alt+shift+s",
+    }
 }


### PR DESCRIPTION
## Changelog Description

Add configurable shortcuts to AYON tools from AYON settings (similar to ayon-nuke)

## Additional review information

<img width="401" height="495" alt="image" src="https://github.com/user-attachments/assets/fc84556c-5e02-49ef-b84a-d9868c9c7a99" />

Fix https://github.com/ynput/ayon-silhouette/issues/53

## Testing notes:

1. Shortcuts should work
2. Shortcuts should be ignored if left empty in settings
3. Defaults should be acceptable (matched the defaults from `ayon-nuke` currently)