### PR TITLE
Make creator default variants configurable in settings

### DIFF
--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -20,6 +20,10 @@ class CreatePluginModel(BaseSettingsModel):
         True,
         title="Enabled",
     )
+    default_variants: list[str] = SettingsField(
+        default_factory=list,
+        title="Default Variants"
+    )
     product_type_items: list[ProductTypeItemModel] = SettingsField(
         default_factory=list,
         title="Product type items",
@@ -47,14 +51,17 @@ class CreatePluginsModel(BaseSettingsModel):
 DEFAULT_SILHOUETTE_CREATE_SETTINGS = {
     "CreateMatteShapes": {
         "enabled": True,
+        "default_variants": ["Main"],
         "product_type_items": [],
     },
     "CreateRender": {
         "enabled": True,
+        "default_variants": ["Main"],
         "product_type_items": [],
     },
     "CreateTrackPoints": {
         "enabled": True,
+        "default_variants": ["Main"],
         "product_type_items": [],
     },
 }


### PR DESCRIPTION
## Changelog Description

Make creator default variants configurable in settings

## Additional review information

<img width="722" height="214" alt="image" src="https://github.com/user-attachments/assets/73f05915-7f4f-41e9-9098-b3a2d0fd87a6" />
<img width="1599" height="260" alt="image" src="https://github.com/user-attachments/assets/6e47ca85-c2ae-4a0e-b388-5e39ebd65240" />


Fix #57

## Testing notes:
1. Default variants are configurable in settings and influence the default variant in publisher UI + show up in the list of variants
